### PR TITLE
Add POSTGIS extension as an option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitconfig
 oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm
 oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
+openshift/postgis-secrets.yaml

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,70 @@
 # OpenShift Postgresql / Oracle FDW #
-This repository can be used to build a container featuring Postgresql 9.6, Oracle FDW
+This repository can be used to build a container featuring Postgresql, Oracle FDW and optionally the pgcrypto and postgis extensions.
 
 The container features an auto-provisioning step on startup that can be used to establish the connection to Oracle.
+
+## Versions ##
+PostgreSQL versions currently supported are:
+
+- postgresql-9.5
+- postgresql-9.6
+
+PostGIS versions currently supported are:
+- postGIS 2.4
+
+RHEL versions currently supported are:
+- RHEL7
+
+CentOS versions currently supported are:
+- CentOS7
+
+## Installation ## 
+
+To disable PostGIS, deploy with the environment variable POSTGIS_EXTENSION=N.
+
+To disable pgcrypto, deploy with the environment variable PGCRYPTO_EXTENSION=N.
+
+Otherwise, the deployment will default to `Y`.
+
+### Confirm extensions ### 
+
+Here are the shell commands to confirm the successful creation of the extensions (assuming POSTGIS_EXTENSION and
+PGCRYPTO_EXTENSION are set to `Y`):
+```
+sh-4.2$ psql -d ${POSTGRESQL_DATABASE} -U ${POSTGRESQL_USER} -c "\dx;"
+                                     List of installed extensions
+   Name     | Version |   Schema   |                             Description
+------------+---------+------------+---------------------------------------------------------------------
+ oracle_fdw | 1.1     | public     | foreign data wrapper for Oracle access
+ pgcrypto   | 1.3     | public     | cryptographic functions
+ plpgsql    | 1.0     | pg_catalog | PL/pgSQL procedural language
+ postgis    | 2.4.5   | public     | PostGIS geometry, geography, and raster spatial types and functions
+(4 rows)
+```
+
+Here is the shell command to confirm the verion of PostGIS ((assuming POSTGIS_EXTENSION was set to `Y`):
+```
+sh-4.2$ psql -d ${POSTGRESQL_DATABASE} -U ${POSTGRESQL_USER} -c "SELECT postgis_full_version();"
+                                      postgis_full_version
+--------------------------------------------------------------------------------------------------------
+ POSTGIS="2.4.5 r16765" PGSQL="96" GEOS="3.6.3-CAPI-1.10.3 80c13047" PROJ="Rel. 4.9.3, 15 August 2016" G
+DAL="GDAL 1.11.4, released 2016/01/25" LIBXML="2.9.1" LIBJSON="0.11" RASTER
+(1 row)
+```
+
+### Choose either the CentOS7 or RHEL7 based image: ###
+
+RHEL7 based image
+
+```
+docker build . -f rhel7.rh-postgresql96/Dockerfile
+```
+
+CentOS7 based image
+
+```
+docker build . -f centos7.rh-postgresql96/Dockerfile
+```
 
 ## Source ##
 

--- a/cccp.yml
+++ b/cccp.yml
@@ -1,1 +1,0 @@
-job-id: postgresql-96-centos7

--- a/centos7.rh-postgresql95/Dockerfile
+++ b/centos7.rh-postgresql95/Dockerfile
@@ -1,6 +1,6 @@
-FROM centos:centos7
+FROM centos:centos7 
 
-# PostgreSQL image for OpenShift.
+# PostgreSQL image for OpenShift with PostGIS extension.
 # Volumes:
 #  * /var/lib/psql/data   - Database cluster for PostgreSQL
 # Environment:
@@ -10,8 +10,10 @@ FROM centos:centos7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
-ENV POSTGRESQL_VERSION=9.6 \
-    POSTGRESQL_PREV_VERSION=9.5 \
+ENV POSTGIS_EXTENSION=Y \
+    PGCRYPTO_EXTENSION=Y \
+    POSTGRESQL_VERSION=9.5 \
+    POSTGRESQL_PREV_VERSION=9.4 \
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
@@ -23,12 +25,12 @@ create, run, maintain and access a PostgreSQL DBMS server."
 LABEL summary=$SUMMARY \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="PostgreSQL 9.6" \
+      io.k8s.display-name="PostgreSQL 9.5" \
       io.openshift.expose-services="5432:postgresql" \
-      io.openshift.tags="database,postgresql,postgresql96,rh-postgresql96" \
-      name="centos/postgresql-96-centos7" \
-      com.redhat.component="rh-postgresql96-docker" \
-      version="9.6" \
+      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95,postgis,postgis24" \
+      name="centos/postgresql-95-centos7" \
+      com.redhat.component="rh-postgresql95-docker" \
+      version="9.5" \
       release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -40,7 +42,7 @@ COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
 # safe in the future. This should *never* change, the last test is there
 # to make sure of that.
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql96-postgresql-server rh-postgresql96-postgresql-devel" && \
+    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql95 rh-postgresql95-postgresql-contrib nss_wrapper rh-postgresql95-postgresql-server rh-postgresql95-postgresql-devel" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
@@ -71,7 +73,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
-    ENABLED_COLLECTIONS=rh-postgresql96
+    ENABLED_COLLECTIONS=rh-postgresql95
 
 COPY root /
 
@@ -82,7 +84,7 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-VOLUME ["/var/lib/pgsql/data"]
+VOLUME ["/var/lib/pgsql/data", "/var/run/postgresql"]
 
 # install the Oracle dependencies./tmp/oracle_fdw-ORACLE_FDW_2_0_0/oracle_fdw.control
 RUN mkdir -p /tmp/oraclelibs && cd /tmp/oraclelibs && \
@@ -93,9 +95,9 @@ RUN mkdir -p /tmp/oraclelibs && cd /tmp/oraclelibs && \
 
 COPY root /
 
-ENV PGCONFIG /opt/rh/rh-postgresql96/root/usr/bin
+ENV PGCONFIG /opt/rh/rh-postgresql95/root/usr/bin
 ENV ORACLE_HOME /usr/lib/oracle/12.2/client64/lib
-ENV PATH /opt/rh/rh-postgresql96/root/usr/bin/:${PATH}
+ENV PATH /opt/rh/rh-postgresql95/root/usr/bin/:${PATH}
 
 # aquire and build ORACLE_FDW_2_0_0
 RUN cd /tmp && \
@@ -104,11 +106,21 @@ RUN cd /tmp && \
     cd oracle_fdw-ORACLE_FDW_2_0_0   && \
     make && \
     make install && \
-    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /var/cache/yum
+    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /tmp/ORACLE_FDW_2_0_0 /var/cache/yum
+
+# Aquire and build PostGIS 2.4, for PostgreSQL 9.5
+RUN cd /tmp && \
+    rpm -ivh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-3.noarch.rpm && \
+    yum install -y epel-release && \
+    yum install -y postgis24_95 postgis24_95-client && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.5/lib/postgis* '/opt/rh/rh-postgresql95/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.5/lib/rtpostgis* '/opt/rh/rh-postgresql95/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 644 /usr/pgsql-9.5/share/extension/postgis* '/opt/rh/rh-postgresql95/root/usr/share/pgsql/extension/' && \
+    mv /usr/pgsql-9.5/share/contrib/postgis-2.4/ /opt/rh/rh-postgresql95/root/usr/share/pgsql/contrib/ && \
+    rm -rf /tmp/pgdg-centos95-9.5-3.noarch.rpm /var/cache/yum 
 
 # set the oracle library path
 ENV LD_LIBRARY_PATH /usr/lib/oracle/12.2/client64/lib:${LD_LIBRARY_PATH}
-
 USER 26
 
 ENTRYPOINT ["container-entrypoint"]

--- a/centos7.rh-postgresql96/Dockerfile
+++ b/centos7.rh-postgresql96/Dockerfile
@@ -1,0 +1,127 @@
+FROM centos:centos7 
+
+# PostgreSQL image for OpenShift with PostGIS extension.
+# Volumes:
+#  * /var/lib/psql/data   - Database cluster for PostgreSQL
+# Environment:
+#  * $POSTGRESQL_USER     - Database user name
+#  * $POSTGRESQL_PASSWORD - User's password
+#  * $POSTGRESQL_DATABASE - Name of the database to create
+#  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
+#                           PostgreSQL administrative account
+
+ENV POSTGIS_EXTENSION=Y \
+    PGCRYPTO_EXTENSION=Y \
+    POSTGRESQL_VERSION=9.6 \
+    POSTGRESQL_PREV_VERSION=9.5 \
+    HOME=/var/lib/pgsql \
+    PGUSER=postgres
+
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="PostgreSQL 9.6" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="database,postgresql,postgresql96,rh-postgresql96,postgis,postgis24" \
+      name="centos/postgresql-96-centos7" \
+      com.redhat.component="rh-postgresql96-docker" \
+      version="9.6" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 5432
+
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+
+# This image must forever use UID 26 for postgres user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql96-postgresql-server rh-postgresql96-postgresql-devel" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+    test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
+    mkdir -p /var/lib/pgsql/data && \
+    /usr/libexec/fix-permissions /var/lib/pgsql && \
+    /usr/libexec/fix-permissions /var/run/postgresql
+
+# install dev tools used to compile ORACLE_FDW_2_0_0
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+	yum-config-manager --enable rhel-7-server-eus-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum -y groupinstall 'Development Tools' && \
+    yum clean all
+
+# install dev tools used to compile ORACLE_FDW_2_0_0
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+	yum-config-manager --enable rhel-7-server-eus-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+	INSTALL_PKGS="wget libaio-devel" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
+    ENABLED_COLLECTIONS=rh-postgresql96
+
+COPY root /
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+VOLUME ["/var/lib/pgsql/data", "/var/run/postgresql"]
+
+# install the Oracle dependencies./tmp/oracle_fdw-ORACLE_FDW_2_0_0/oracle_fdw.control
+RUN mkdir -p /tmp/oraclelibs && cd /tmp/oraclelibs && \
+    wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm && \
+    wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm && \
+    rpm -Uvh oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm && \
+    rpm -Uvh oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
+
+COPY root /
+
+ENV PGCONFIG /opt/rh/rh-postgresql96/root/usr/bin
+ENV ORACLE_HOME /usr/lib/oracle/12.2/client64/lib
+ENV PATH /opt/rh/rh-postgresql96/root/usr/bin/:${PATH}
+
+# aquire and build ORACLE_FDW_2_0_0
+RUN cd /tmp && \
+    wget -nv https://github.com/laurenz/oracle_fdw/archive/ORACLE_FDW_2_0_0.tar.gz && \
+    tar -xzf ORACLE_FDW_2_0_0.tar.gz && \
+    cd oracle_fdw-ORACLE_FDW_2_0_0   && \
+    make && \
+    make install && \
+    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /tmp/ORACLE_FDW_2_0_0 /var/cache/yum
+
+# Aquire and build PostGIS 2.4, for PostgreSQL 9.6
+RUN cd /tmp && \
+    rpm -ivh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm && \
+    yum install -y epel-release && \
+    yum install -y postgis24_96 postgis24_96-client && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.6/lib/postgis* '/opt/rh/rh-postgresql96/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.6/lib/rtpostgis* '/opt/rh/rh-postgresql96/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 644 /usr/pgsql-9.6/share/extension/postgis* '/opt/rh/rh-postgresql96/root/usr/share/pgsql/extension/' && \
+    mv /usr/pgsql-9.6/share/contrib/postgis-2.4/ /opt/rh/rh-postgresql96/root/usr/share/pgsql/contrib/ && \
+    rm -rf /tmp/pgdg-centos96-9.6-3.noarch.rpm /var/cache/yum 
+
+# set the oracle library path
+ENV LD_LIBRARY_PATH /usr/lib/oracle/12.2/client64/lib:${LD_LIBRARY_PATH}
+USER 26
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-postgresql"]

--- a/openshift/postgresql95-postgis24-oracle-fdw.sample.bc.json
+++ b/openshift/postgresql95-postgis24-oracle-fdw.sample.bc.json
@@ -1,0 +1,41 @@
+{
+    "kind": "BuildConfig",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "openshift-postgis-oraclefdw",
+        "labels": {
+            "app": "openshift-postgis-oraclefdw"
+        }
+    },
+    "spec": {
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            }
+        ],
+        "runPolicy": "Serial",
+        "source": {
+            "type": "Git",
+            "git": {
+                "uri": "https://github.com/garywong-bc/openshift-postgresql-oracle_fdw.git",
+                "ref": "master"
+            }
+        },
+        "strategy": {
+            "type": "Docker",
+            "dockerStrategy": {
+                "noCache": false,
+                "dockerfilePath": "rhel7.rh-postgresql95/Dockerfile"
+            }
+        },
+        "output": {
+            "to": {
+                "kind": "ImageStreamTag",
+                "name": "postgis-oracle-fdw:95-24"
+            }
+        },
+        "resources": {},
+        "postCommit": {},
+        "nodeSelector": null
+    }
+}

--- a/openshift/postgresql95-postgis24-oracle-fdw.sample.dc.json
+++ b/openshift/postgresql95-postgis24-oracle-fdw.sample.dc.json
@@ -1,0 +1,147 @@
+{
+    "kind": "DeploymentConfig",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgis-oracle-fdw",
+        "generation": 1,
+        "labels": {
+            "app": "postgis-oracle-fdw"
+        }
+    },
+    "spec": {
+        "strategy": {
+            "type": "Recreate",
+            "recreateParams": {
+                "timeoutSeconds": 600
+            },
+            "resources": {},
+            "activeDeadlineSeconds": 21600
+        },
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            },
+            {
+                "type": "ImageChange",
+                "imageChangeParams": {
+                    "automatic": true,
+                    "containerNames": [
+                        "postgis-oracle-fdw"
+                    ],
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "namespace": "csnr-devops-lab-tools",
+                        "name": "postgis-oracle-fdw:95-24"
+                    }
+                }
+            }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+            "app": "postgis-oracle-fdw",
+            "deploymentconfig": "postgis-oracle-fdw"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "postgis-oracle-fdw",
+                    "deploymentconfig": "postgis-oracle-fdw"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftWebConsole"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "postgis-oracle-fdw-1",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "postgis-oracle-fdw-2",
+                        "emptyDir": {}
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "postgis-oracle-fdw",
+                        "image": " ",
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "POSTGRESQL_USER",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "POSTGRESQL_PASSWORD",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "POSTGRESQL_DATABASE",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_USER",
+                                "value": "demo"
+                            },
+                            {
+                                "name": "FDW_PASS",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_FOREIGN_SERVER",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_FOREIGN_SCHEMA",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_NAME",
+                                "value": "wells_oradb"
+                            },
+                            {
+                                "name": "FDW_SCHEMA",
+                                "value": "wells"
+                            },
+                            {
+                                "name": "PGCRYPTO_EXTENSION",
+                                "value": "Y"
+                            },
+                            {
+                                "name": "POSTGIS_EXTENSION",
+                                "value": "Y"
+                            }
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "postgis-oracle-fdw-1",
+                                "mountPath": "/var/lib/pgsql/data"
+                            },
+                            {
+                                "name": "postgis-oracle-fdw-2",
+                                "mountPath": "/var/run/postgresql"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            }
+        }
+    }
+}

--- a/openshift/postgresql96-postgis24-oracle-fdw.sample.bc.json
+++ b/openshift/postgresql96-postgis24-oracle-fdw.sample.bc.json
@@ -1,0 +1,41 @@
+{
+    "kind": "BuildConfig",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "openshift-postgis-oraclefdw",
+        "labels": {
+            "app": "openshift-postgis-oraclefdw"
+        }
+    },
+    "spec": {
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            }
+        ],
+        "runPolicy": "Serial",
+        "source": {
+            "type": "Git",
+            "git": {
+                "uri": "https://github.com/garywong-bc/openshift-postgresql-oracle_fdw.git",
+                "ref": "master"
+            }
+        },
+        "strategy": {
+            "type": "Docker",
+            "dockerStrategy": {
+                "noCache": false,
+                "dockerfilePath": "rhel7.rh-postgresql96/Dockerfile"
+            }
+        },
+        "output": {
+            "to": {
+                "kind": "ImageStreamTag",
+                "name": "postgis-oracle-fdw:96-24"
+            }
+        },
+        "resources": {},
+        "postCommit": {},
+        "nodeSelector": null
+    }
+}

--- a/openshift/postgresql96-postgis24-oracle-fdw.sample.dc.json
+++ b/openshift/postgresql96-postgis24-oracle-fdw.sample.dc.json
@@ -1,0 +1,147 @@
+{
+    "kind": "DeploymentConfig",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "postgis-oracle-fdw",
+        "generation": 1,
+        "labels": {
+            "app": "postgis-oracle-fdw"
+        }
+    },
+    "spec": {
+        "strategy": {
+            "type": "Recreate",
+            "recreateParams": {
+                "timeoutSeconds": 600
+            },
+            "resources": {},
+            "activeDeadlineSeconds": 21600
+        },
+        "triggers": [
+            {
+                "type": "ConfigChange"
+            },
+            {
+                "type": "ImageChange",
+                "imageChangeParams": {
+                    "automatic": true,
+                    "containerNames": [
+                        "postgis-oracle-fdw"
+                    ],
+                    "from": {
+                        "kind": "ImageStreamTag",
+                        "namespace": "csnr-devops-lab-tools",
+                        "name": "postgis-oracle-fdw:96-24"
+                    }
+                }
+            }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+            "app": "postgis-oracle-fdw",
+            "deploymentconfig": "postgis-oracle-fdw"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "postgis-oracle-fdw",
+                    "deploymentconfig": "postgis-oracle-fdw"
+                },
+                "annotations": {
+                    "openshift.io/generated-by": "OpenShiftWebConsole"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "postgis-oracle-fdw-1",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "postgis-oracle-fdw-2",
+                        "emptyDir": {}
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "postgis-oracle-fdw",
+                        "image": " ",
+                        "ports": [
+                            {
+                                "containerPort": 5432,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "POSTGRESQL_USER",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "POSTGRESQL_PASSWORD",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "POSTGRESQL_DATABASE",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_USER",
+                                "value": "demo"
+                            },
+                            {
+                                "name": "FDW_PASS",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_FOREIGN_SERVER",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_FOREIGN_SCHEMA",
+                                "value": "demo" 
+                            },
+                            {
+                                "name": "FDW_NAME",
+                                "value": "wells_oradb"
+                            },
+                            {
+                                "name": "FDW_SCHEMA",
+                                "value": "wells"
+                            },
+                            {
+                                "name": "PGCRYPTO_EXTENSION",
+                                "value": "Y"
+                            },
+                            {
+                                "name": "POSTGIS_EXTENSION",
+                                "value": "Y"
+                            }
+                        ],
+                        "resources": {},
+                        "volumeMounts": [
+                            {
+                                "name": "postgis-oracle-fdw-1",
+                                "mountPath": "/var/lib/pgsql/data"
+                            },
+                            {
+                                "name": "postgis-oracle-fdw-2",
+                                "mountPath": "/var/run/postgresql"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "imagePullPolicy": "Always"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+                "dnsPolicy": "ClusterFirst",
+                "securityContext": {},
+                "schedulerName": "default-scheduler"
+            }
+        }
+    }
+}

--- a/rhel7.rh-postgresql95/Dockerfile
+++ b/rhel7.rh-postgresql95/Dockerfile
@@ -1,6 +1,6 @@
 FROM rhel7
 
-# PostgreSQL image for OpenShift.
+# PostgreSQL image for OpenShift with PostGIS extension.
 # Volumes:
 #  * /var/lib/psql/data   - Database cluster for PostgreSQL
 # Environment:
@@ -10,8 +10,15 @@ FROM rhel7
 #  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
 #                           PostgreSQL administrative account
 
+<<<<<<< HEAD:rhel7.rh-postgresql95/Dockerfile
+ENV POSTGIS_EXTENSION=Y \
+    PGCRYPTO_EXTENSION=Y \
+    POSTGRESQL_VERSION=9.5 \
+    POSTGRESQL_PREV_VERSION=9.4 \
+=======
 ENV POSTGRESQL_VERSION=9.6 \
     POSTGRESQL_PREV_VERSION=9.5 \
+>>>>>>> 18d6aeabc4d539009804b1eebbd44ee45911d242:Dockerfile.rhel7
     HOME=/var/lib/pgsql \
     PGUSER=postgres
 
@@ -25,10 +32,17 @@ LABEL summary=$SUMMARY \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="PostgreSQL 9.6" \
       io.openshift.expose-services="5432:postgresql" \
+<<<<<<< HEAD:rhel7.rh-postgresql95/Dockerfile
+      io.openshift.tags="database,postgresql,postgresql95,rh-postgresql95,postgis,postgis24" \
+      name="rhscl/postgresql-95-rhel7" \
+      com.redhat.component="rh-postgresql95-docker" \
+      version="9.5" \
+=======
       io.openshift.tags="database,postgresql,postgresql96,rh-postgresql96" \
       name="rhscl/postgresql-96-rhel7" \
       com.redhat.component="rh-postgresql96-docker" \
       version="9.6" \
+>>>>>>> 18d6aeabc4d539009804b1eebbd44ee45911d242:Dockerfile.rhel7
       release="1"
 
 EXPOSE 5432
@@ -88,9 +102,9 @@ ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
     PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
 
-VOLUME ["/var/lib/pgsql/data"]
+VOLUME ["/var/lib/pgsql/data", "/var/run/postgresql"]
 
-# install the Oracle dependencies.
+# install the Oracle dependencies./tmp/oracle_fdw-ORACLE_FDW_2_0_0/oracle_fdw.control
 RUN mkdir -p /tmp/oraclelibs && cd /tmp/oraclelibs && \
     wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm && \
     wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm && \
@@ -101,7 +115,7 @@ COPY root /
 
 ENV PGCONFIG /opt/rh/rh-postgresql96/root/usr/bin
 ENV ORACLE_HOME /usr/lib/oracle/12.2/client64/lib
-ENV PATH /opt/rh/rh-postgresql96/root/usr/bin/:${PATH}
+ENV PATH /opt/rh/rh-postgresql95/root/usr/bin/:${PATH}
 
 # aquire and build ORACLE_FDW_2_0_0
 RUN cd /tmp && \
@@ -110,11 +124,21 @@ RUN cd /tmp && \
     cd oracle_fdw-ORACLE_FDW_2_0_0   && \
     make && \
     make install && \
-    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /var/cache/yum
+    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /tmp/ORACLE_FDW_2_0_0 /var/cache/yum
+
+# Aquire and build PostGIS 2.4, for PostgreSQL 9.5
+RUN cd /tmp && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    rpm -ivh https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-redhat95-9.5-3.noarch.rpm && \
+    yum install -y postgis24_95 postgis24_95-client && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.5/lib/postgis* '/opt/rh/rh-postgresql95/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.5/lib/rtpostgis* '/opt/rh/rh-postgresql95/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 644 /usr/pgsql-9.5/share/extension/postgis* '/opt/rh/rh-postgresql95/root/usr/share/pgsql/extension/' && \
+    mv /usr/pgsql-9.5/share/contrib/postgis-2.4/ /opt/rh/rh-postgresql95/root/usr/share/pgsql/contrib/ && \
+    rm -rf /tmp/pgdg-redhat95-9.5-3.noarch.rpm /var/cache/yum 
 
 # set the oracle library path
 ENV LD_LIBRARY_PATH /usr/lib/oracle/12.2/client64/lib:${LD_LIBRARY_PATH}
-
 USER 26
 
 ENTRYPOINT ["container-entrypoint"]

--- a/rhel7.rh-postgresql96/Dockerfile
+++ b/rhel7.rh-postgresql96/Dockerfile
@@ -1,0 +1,133 @@
+FROM rhel7
+
+# PostgreSQL image for OpenShift with PostGIS extension.
+# Volumes:
+#  * /var/lib/psql/data   - Database cluster for PostgreSQL
+# Environment:
+#  * $POSTGRESQL_USER     - Database user name
+#  * $POSTGRESQL_PASSWORD - User's password
+#  * $POSTGRESQL_DATABASE - Name of the database to create
+#  * $POSTGRESQL_ADMIN_PASSWORD (Optional) - Password for the 'postgres'
+#                           PostgreSQL administrative account
+
+ENV POSTGIS_EXTENSION=Y \
+    PGCRYPTO_EXTENSION=Y \
+    POSTGRESQL_VERSION=9.6 \
+    POSTGRESQL_PREV_VERSION=9.5 \
+    HOME=/var/lib/pgsql \
+    PGUSER=postgres
+
+ENV SUMMARY="PostgreSQL is an advanced Object-Relational database management system" \
+    DESCRIPTION="PostgreSQL is an advanced Object-Relational database management system (DBMS). \
+The image contains the client and server programs that you'll need to \
+create, run, maintain and access a PostgreSQL DBMS server."
+
+LABEL summary=$SUMMARY \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="PostgreSQL 9.6" \
+      io.openshift.expose-services="5432:postgresql" \
+      io.openshift.tags="database,postgresql,postgresql96,rh-postgresql96,postgis,postgis24" \
+      name="rhscl/postgresql-96-rhel7" \
+      com.redhat.component="rh-postgresql96-docker" \
+      version="9.6" \
+      release="1"
+
+EXPOSE 5432
+
+COPY root/usr/libexec/fix-permissions /usr/libexec/fix-permissions
+
+# This image must forever use UID 26 for postgres user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+# rhel-7-server-ose-3.2-rpms is enabled for nss_wrapper until this pkg is
+# in base RHEL
+#
+# We need to call 2 (!) yum commands before being able to enable repositories properly
+# This is a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1479388
+RUN yum repolist > /dev/null && \
+    yum install -y yum-utils gettext && \
+    yum-config-manager --disable \* &> /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    INSTALL_PKGS="rsync tar gettext bind-utils rh-postgresql96 rh-postgresql96-postgresql-contrib nss_wrapper rh-postgresql96-postgresql-server rh-postgresql96-postgresql-devel" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8 && \
+    test "$(id postgres)" = "uid=26(postgres) gid=26(postgres) groups=26(postgres)" && \
+    mkdir -p /var/lib/pgsql/data && \
+    /usr/libexec/fix-permissions /var/lib/pgsql && \
+    /usr/libexec/fix-permissions /var/run/postgresql
+
+# install dev tools used to compile ORACLE_FDW_2_0_0
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-eus-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum -y groupinstall 'Development Tools' && \
+    yum clean all
+
+# install dev tools used to compile ORACLE_FDW_2_0_0
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-rpms && \
+    yum-config-manager --enable rhel-7-server-eus-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    INSTALL_PKGS="wget libaio-devel" && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all
+
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/postgresql \
+    ENABLED_COLLECTIONS=rh-postgresql96
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+VOLUME ["/var/lib/pgsql/data", "/var/run/postgresql"]
+
+# install the Oracle dependencies./tmp/oracle_fdw-ORACLE_FDW_2_0_0/oracle_fdw.control
+RUN mkdir -p /tmp/oraclelibs && cd /tmp/oraclelibs && \
+    wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm && \
+    wget -nv https://www.pathfinder.gov.bc.ca/filestore/oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm && \
+    rpm -Uvh oracle-instantclient12.2-basic-12.2.0.1.0-1.x86_64.rpm && \
+    rpm -Uvh oracle-instantclient12.2-devel-12.2.0.1.0-1.x86_64.rpm
+
+COPY root /
+
+ENV PGCONFIG /opt/rh/rh-postgresql96/root/usr/bin
+ENV ORACLE_HOME /usr/lib/oracle/12.2/client64/lib
+ENV PATH /opt/rh/rh-postgresql96/root/usr/bin/:${PATH}
+
+# aquire and build ORACLE_FDW_2_0_0
+RUN cd /tmp && \
+    wget -nv https://github.com/laurenz/oracle_fdw/archive/ORACLE_FDW_2_0_0.tar.gz && \
+    tar -xzf ORACLE_FDW_2_0_0.tar.gz && \
+    cd oracle_fdw-ORACLE_FDW_2_0_0   && \
+    make && \
+    make install && \
+    rm -rf /tmp/oraclelibs /tmp/ORACLE_FDW_2_0_0.tar.gz /tmp/ORACLE_FDW_2_0_0 /var/cache/yum
+
+# Aquire and build PostGIS 2.4, for PostgreSQL 9.6
+RUN cd /tmp && \
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    rpm -ivh https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-redhat96-9.6-3.noarch.rpm && \
+    yum install -y postgis24_96 postgis24_96-client && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.6/lib/postgis* '/opt/rh/rh-postgresql96/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 755  /usr/pgsql-9.6/lib/rtpostgis* '/opt/rh/rh-postgresql96/root/usr/lib64/pgsql/' && \
+    /usr/bin/install -c -m 644 /usr/pgsql-9.6/share/extension/postgis* '/opt/rh/rh-postgresql96/root/usr/share/pgsql/extension/' && \
+    mv /usr/pgsql-9.6/share/contrib/postgis-2.4/ /opt/rh/rh-postgresql96/root/usr/share/pgsql/contrib/ && \
+    rm -rf /tmp/pgdg-redhat96-9.6-3.noarch.rpm /var/cache/yum 
+
+# set the oracle library path
+ENV LD_LIBRARY_PATH /usr/lib/oracle/12.2/client64/lib:${LD_LIBRARY_PATH}
+USER 26
+
+ENTRYPOINT ["container-entrypoint"]
+CMD ["run-postgresql"]

--- a/root/usr/bin/run-postgresql
+++ b/root/usr/bin/run-postgresql
@@ -31,6 +31,7 @@ if [ ! -f "$PGDATA/fdw.conf" ]; then
   create_fdw
 fi
 
+create_postgis_pgcrypto
 set_passwords
 pg_ctl stop
 

--- a/test/run
+++ b/test/run
@@ -1,1 +1,0 @@
-../../hack/run_test


### PR DESCRIPTION
- Refactored version so that PGCRYPTO extension is an option (rather than hardcoded), removed cccp.yml file, and cleaned up /tmp files
- Added POSTGIS extension (v2.4) as an option
- Added subfolders for centos/rhel7 and Postgresql9.5/9.6 options
- Added openshift folder to hold sample *.dc and *.bc files
